### PR TITLE
Implementada validação para garantir integridade dos atributos datas de um Training

### DIFF
--- a/src/main/java/io/github/lucasduete/rhtapi/controllers/TrainingController.java
+++ b/src/main/java/io/github/lucasduete/rhtapi/controllers/TrainingController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("training")
 public class TrainingController {
@@ -17,7 +19,7 @@ public class TrainingController {
     }
 
     @PostMapping
-    public ResponseEntity saveTraining(@RequestBody Training training) {
+    public ResponseEntity saveTraining(@RequestBody @Valid Training training) {
         if (training == null) return ResponseEntity.badRequest().body("Training can't be null");
 
         Training savedTraining = this.service.save(training);

--- a/src/main/java/io/github/lucasduete/rhtapi/controllers/validators/training/TrainingDatesContraintValidator.java
+++ b/src/main/java/io/github/lucasduete/rhtapi/controllers/validators/training/TrainingDatesContraintValidator.java
@@ -1,0 +1,45 @@
+package io.github.lucasduete.rhtapi.controllers.validators.training;
+
+import io.github.lucasduete.rhtapi.models.Training;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+/**
+ * Implemention of {@link TrainingDatesValidator} to {@link Training}
+ */
+@Component
+public class TrainingDatesContraintValidator implements ConstraintValidator<TrainingDatesValidator, Training> {
+
+    public TrainingDatesContraintValidator() {
+
+    }
+
+    @Override
+    public boolean isValid(final Training training, final ConstraintValidatorContext constraintValidatorContext) {
+        final LocalDate dateStart = training.getDateStart();
+        final LocalDate dateFinish = training.getDateFinish();
+
+        /**
+         * Both Dates can't be before today
+         */
+        if (dateStart.isBefore(LocalDate.now()) || dateFinish.isBefore(LocalDate.now())) {
+            return false;
+        }
+
+        /**
+         * DateFinish must be after or equals to DateStart
+         */
+        if (dateFinish.isBefore(dateStart)) {
+            return false;
+        }
+
+        /**
+         * Otherwise is valid
+         */
+        return true;
+    }
+
+}

--- a/src/main/java/io/github/lucasduete/rhtapi/controllers/validators/training/TrainingDatesValidator.java
+++ b/src/main/java/io/github/lucasduete/rhtapi/controllers/validators/training/TrainingDatesValidator.java
@@ -1,0 +1,24 @@
+package io.github.lucasduete.rhtapi.controllers.validators.training;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+/**
+ * Annotation that validate:
+ * 1. Both Dates can't be before today
+ * 2. DateFinish must be after or equals to DateStart
+ */
+@Documented
+@Constraint(validatedBy = TrainingDatesContraintValidator.class)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE_PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrainingDatesValidator {
+
+    String message() default "As datas são inválidas, a data de inicio e fim devem ser no mínimo a data de hoje. A data final deve ser posterior a data de inicio.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/io/github/lucasduete/rhtapi/models/Training.java
+++ b/src/main/java/io/github/lucasduete/rhtapi/models/Training.java
@@ -3,6 +3,7 @@ package io.github.lucasduete.rhtapi.models;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import io.github.lucasduete.rhtapi.controllers.validators.training.TrainingDatesValidator;
 import lombok.*;
 
 import javax.persistence.*;
@@ -22,6 +23,7 @@ import java.util.List;
 @AllArgsConstructor
 @EqualsAndHashCode
 @ToString
+@TrainingDatesValidator
 public class Training implements Serializable {
 
     @Id


### PR DESCRIPTION
Implementada validação para garantir integridade dos atributos datas de um Training.
As validações atualmente são:
 1. Both Dates can't be before today
 2. DateFinish must be after or equals to DateStart